### PR TITLE
Make types optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-collapsible",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-collapsible",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "svelte-collapse": "^0.1.1"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,16 +1,16 @@
 declare module "svelte-collapsible" {
   import { SvelteComponentTyped } from "svelte";
   export class Accordion extends SvelteComponentTyped<{
-    duration: number;
-    easing: string;
-    key: any;
+    duration?: number;
+    easing?: string;
+    key?: any;
   }> {}
   export class AccordionItem extends SvelteComponentTyped<{
-    key: any;
+    key?: any;
   }> {}
   export class CollapsibleCard extends SvelteComponentTyped<{
-    open: boolean;
-    duration: number;
-    easing: string;
+    open?: boolean;
+    duration?: number;
+    easing?: string;
   }> {}
 }


### PR DESCRIPTION
I get this error when trying to use `CollapsibleCard`:

`Type '{}' is missing the following properties from type '{ open: boolean; duration: number; easing: string; }': open, duration, easingts(2739)`

Package versions on my project where I'm using `CollapsibleCard`:
```
"devDependencies": {
	"@sveltejs/adapter-auto": "2.1.0",
	"@sveltejs/kit": "1.25.0",
	"@typescript-eslint/eslint-plugin": "6.7.0",
	"@typescript-eslint/parser": "6.7.0",
	"eslint": "8.49.0",
	"eslint-config-prettier": "9.0.0",
	"eslint-plugin-svelte": "2.33.1",
	"prettier": "3.0.3",
	"prettier-plugin-svelte": "3.0.3",
	"svelte": "4.2.0",
	"svelte-check": "3.5.1",
	"tslib": "2.6.2",
	"typescript": "5.2.2",
	"vite": "4.4.9"
},
"dependencies": {
	"svelte-collapsible": "0.2.2"
}
```

I see all the svelte-collapsible component properties actually have default values, so I just went ahead and made them all optional in the types. This fixes the error message for me.