### PR TITLE
Fix a11y warning by removing aria-expanded from li

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-collapsible",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-collapsible",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "svelte-collapse": "^0.1.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "svelte-collapsible",
   "description": "A collection of high-level Svelte components designed for expanding and collapsing content.",
   "keywords": ["svelte", "component", "accordion", "collapse", "expand"],
-  "version": "0.2.2",
+  "version": "0.3.0",
   "svelte": "src/index.js",
   "module": "dist/index.mjs",
   "main": "dist/index.js",

--- a/src/components/AccordionItem.svelte
+++ b/src/components/AccordionItem.svelte
@@ -28,7 +28,7 @@
 
 </script>
 
-<li class='accordion-item' aria-expanded={params.open}>
+<li class='accordion-item' class:open={params.open}>
 
     <button type="button" on:click={handleToggle} class='accordion-item-header'>
         <slot name='header' />


### PR DESCRIPTION
I got this a11y warning:
`A11y: The attribute 'aria-expanded' is not supported by the role 'listitem'. This role is implicit on the element <li>.svelte(a11y-role-supports-aria-props)`

One way of fixing it is to just use an `open` class instead. This is a breaking change, so I bumped the major version number.